### PR TITLE
Infinite loop when using the SeparateGroups option

### DIFF
--- a/src/lib/mark.js
+++ b/src/lib/mark.js
@@ -478,7 +478,7 @@ class Mark {
    */
   separateGroups(node, match, matchIdx, filterCb, eachCb) {
     let matchLen = match.length;
-    for (let i = 0; i < matchLen; i++) {
+    for (let i = 1; i < matchLen; i++) {
       let pos = node.textContent.indexOf(match[i]);
       if (match[i] && pos > -1 && filterCb(match[i], node)) {
         node = this.wrapGroups(node, pos, match[i].length, eachCb);

--- a/src/lib/mark.js
+++ b/src/lib/mark.js
@@ -525,13 +525,17 @@ class Mark {
           match[matchIdx] !== ''
         ) {
           if (this.opt.separateGroups) {
-            node = this.separateGroups(
-              node,
-              match,
-              matchIdx,
-              filterCb,
-              eachCb
-            );
+	    if(match.length !== 1){
+	      node = this.separateGroups(
+		  node,
+		  match,
+		  matchIdx,
+		  filterCb,
+		  eachCb
+              );
+            }else{
+              break;
+            }
           } else {
             if (!filterCb(match[matchIdx], node)) {
               continue;

--- a/src/lib/mark.js
+++ b/src/lib/mark.js
@@ -478,7 +478,7 @@ class Mark {
    */
   separateGroups(node, match, matchIdx, filterCb, eachCb) {
     let matchLen = match.length;
-    for (let i = 1; i < matchLen; i++) {
+    for (let i = 0; i < matchLen; i++) {
       let pos = node.textContent.indexOf(match[i]);
       if (match[i] && pos > -1 && filterCb(match[i], node)) {
         node = this.wrapGroups(node, pos, match[i].length, eachCb);

--- a/src/lib/mark.js
+++ b/src/lib/mark.js
@@ -524,18 +524,14 @@ class Mark {
           (match = regex.exec(node.textContent)) !== null &&
           match[matchIdx] !== ''
         ) {
-          if (this.opt.separateGroups) {
-	    if(match.length !== 1){
-	      node = this.separateGroups(
-		  node,
-		  match,
-		  matchIdx,
-		  filterCb,
-		  eachCb
-              );
-            }else{
-              break;
-            }
+          if (this.opt.separateGroups && match.length !== 1){
+            node = this.separateGroups(
+              node,
+              match,
+              matchIdx,
+              filterCb,
+              eachCb
+            );
           } else {
             if (!filterCb(match[matchIdx], node)) {
               continue;

--- a/test/fixtures/regexp/separate-groups.html
+++ b/test/fixtures/regexp/separate-groups.html
@@ -15,4 +15,9 @@
       ignored (test-1w), {test-2x|lorem-3y} [ipsum-4z] test+ignored
     </p>
   </div>
+  <div>
+    <p>
+      ignored (test-1w), {test-2x|lorem-3y} [ipsum-4z] test+ignored
+    </p>
+  </div>
 </div>

--- a/test/specs/regexp/separate-groups.js
+++ b/test/specs/regexp/separate-groups.js
@@ -1,12 +1,13 @@
 'use strict';
 describe('mark with regular expression and separateGroups', function() {
-  var $ctx1, $ctx2, $ctx3;
+  var $ctx1, $ctx2, $ctx3, $ctx4;
   beforeEach(function(done) {
     loadFixtures('regexp/separate-groups.html');
 
     $ctx1 = $('.regexp-separate-groups > div:nth-child(1)');
     $ctx2 = $('.regexp-separate-groups > div:nth-child(2)');
     $ctx3 = $('.regexp-separate-groups > div:nth-child(3)');
+    $ctx4 = $('.regexp-separate-groups > div:nth-child(4)');
     new Mark($ctx1[0]).markRegExp(/(?:\[%)([a-z_]+):(\w+?)(?:%])/g, {
       separateGroups: true,
       done: function() {
@@ -15,7 +16,12 @@ describe('mark with regular expression and separateGroups', function() {
           done: function() {
             new Mark($ctx3[0]).markRegExp(/(\w+)-(\w+)/g, {
               separateGroups: false,
-              done: done
+              done: function() {
+                new Mark($ctx4[0]).markRegExp(/\w+-\w+/g, {
+                  separateGroups: true,
+                  done: done
+                });
+              }
             });
           }
         });
@@ -44,5 +50,8 @@ describe('mark with regular expression and separateGroups', function() {
   });
   it('should not separate groups when disabled', function() {
     expect($ctx3.find('mark')).toHaveLength(4);
+  });
+  it('should not cause an infinite loop with no groups in regexp', function() {
+    expect($ctx4.find('mark')).toHaveLength(4);
   });
 });


### PR DESCRIPTION
I tried to use the new SeparateGroups feature but was stuck in an infinite loop when I called the "separateGroups" function. I noticed that by starting the iterator at 0 instead of 1 the problem was solved.
